### PR TITLE
Added the design tokens used in the backend and exposed for theming

### DIFF
--- a/src/common/typography.tokens.json
+++ b/src/common/typography.tokens.json
@@ -5,6 +5,21 @@
     },
     "link": {
       "color": {"value": "{of.color.primary}"}
+    },
+    "text": {
+      "margin": {"value": "20px"},
+      "mobile": {
+        "margin": {"value": "{of.text.margin}"}
+      },
+      "tablet": {
+        "margin": {"value": "{of.text.margin}"}
+      },
+      "laptop": {
+        "margin": {"value": "{of.text.margin}"}
+      },
+      "desktop": {
+        "margin": {"value": "{of.text.margin}"}
+      }
     }
   }
 }

--- a/src/common/typography.tokens.json
+++ b/src/common/typography.tokens.json
@@ -4,7 +4,10 @@
       "fg": {"value": "{of.color.fg}"}
     },
     "link": {
-      "color": {"value": "{of.color.primary}"}
+      "color": {"value": "{of.color.primary}"},
+      "hover": {
+        "color": {"value": "{of.link.color}"}
+      }
     },
     "text": {
       "margin": {"value": "20px"},

--- a/src/components/page-footer/tokens.json
+++ b/src/components/page-footer/tokens.json
@@ -1,0 +1,8 @@
+{
+  "of": {
+    "page-footer": {
+      "bg": {"value": "{of.color.primary}"},
+      "fg": {"value": "{of.color.bg}"}
+    }
+  }
+}

--- a/src/components/page-header/logo.tokens.json
+++ b/src/components/page-header/logo.tokens.json
@@ -1,0 +1,9 @@
+{
+  "of": {
+    "header-logo": {
+      "url": {"value": "none"},
+      "width": {"value": "auto"},
+      "height": {"value": "auto"}
+    }
+  }
+}

--- a/src/components/page-header/tokens.json
+++ b/src/components/page-header/tokens.json
@@ -1,0 +1,19 @@
+{
+  "of": {
+    "page-header": {
+      "background": {"value": "#ffffff"},
+      "mobile": {
+        "padding": {"value": "{of.text.mobile.margin}"}
+      },
+      "tablet": {
+        "padding": {"value": "{of.text.tablet.margin}"}
+      },
+      "laptop": {
+        "padding": {"value": "{of.text.laptop.margin}"}
+      },
+      "desktop": {
+        "padding": {"value": "{of.text.desktop.margin}"}
+      }
+    }
+  }
+}

--- a/src/components/page-header/tokens.json
+++ b/src/components/page-header/tokens.json
@@ -1,7 +1,7 @@
 {
   "of": {
     "page-header": {
-      "background": {"value": "#ffffff"},
+      "bg": {"value": "#ffffff"},
       "mobile": {
         "padding": {"value": "{of.text.mobile.margin}"}
       },


### PR DESCRIPTION
First step towards using design tokens in the backend project.

Note that the naming scheme is a bit different, so a data migration in the backend will be needed.