### PR TITLE
add design token for progress indicator item

### DIFF
--- a/src/components/progress-indicator-item.tokens.json
+++ b/src/components/progress-indicator-item.tokens.json
@@ -1,0 +1,9 @@
+{
+  "of": {
+    "progress-indicator-item": {
+      "not-applicable": {
+        "display": {"value": "flex"}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes open-formulieren/open-forms#2444 (in part, complement to open-formulieren/open-forms-sdk#385)

*the token facilitates changing the display of non-applicable steps in the overview of form submissions