### PR TITLE
remove design token for progress item

### DIFF
--- a/src/components/progress-indicator-item.tokens.json
+++ b/src/components/progress-indicator-item.tokens.json
@@ -1,9 +1,0 @@
-{
-  "of": {
-    "progress-indicator-item": {
-      "not-applicable": {
-        "display": {"value": "flex"}
-      }
-    }
-  }
-}


### PR DESCRIPTION
Part of open-formulieren/open-forms#2444

It was decided to implement the feature as a global configuration option, so the design token is no longer necessary.