### PR TITLE
Configure theme for form fields

### DIFF
--- a/src/community/utrecht/form-field-description.tokens.json
+++ b/src/community/utrecht/form-field-description.tokens.json
@@ -7,7 +7,9 @@
       "font-style": {"value": "normal"},
       "invalid": {
         "color": {"value": "{of.color.danger}"}
-      }
+      },
+      "margin-block-end": {"value": "0"},
+      "margin-block-start": {"value": "8px"}
     }
   }
 }

--- a/src/community/utrecht/form-field.tokens.json
+++ b/src/community/utrecht/form-field.tokens.json
@@ -7,6 +7,9 @@
           "width": {"value": "4px"}
         },
         "padding-inline-start": {"value": "16px"}
+      },
+      "label": {
+        "margin-block-end": {"value": "8px"}
       }
     }
   }

--- a/src/community/utrecht/paragraph.tokens.json
+++ b/src/community/utrecht/paragraph.tokens.json
@@ -1,0 +1,8 @@
+{
+  "utrecht": {
+    "paragraph": {
+      "margin-block-end": {"value": 0},
+      "margin-block-start": {"value": 0}
+    }
+  }
+}

--- a/src/components/helptext.tokens.json
+++ b/src/components/helptext.tokens.json
@@ -3,6 +3,21 @@
     "helptext": {
       "bg": {"value": "#d3e3ec"},
       "fg": {"value": "{of.color.fg}"}
+    },
+    "utrecht-form-field-description": {
+      "$extensions": {
+        "dte.metadata": {
+          "groupDescription": "Open Forms extensions of utrecht-form-field-description"
+        }
+      },
+      "background-color": {"value": "#d3e3ec"},
+      "border-left": {
+        "color": {"value": "{of.color.info}"},
+        "width": {"value": "4px"}
+      },
+      "line-height": {"value": "1.5"},
+      "padding-block": {"value": "11px"},
+      "padding-inline": {"value": "16px"}
     }
   }
 }


### PR DESCRIPTION
Closes open-formulieren/open-forms-sdk#442

* Configured community form-field(-description) design tokens for own theme
* Configured default design tokens for Open Forms extensions of community components
* Configured utrecht-paragraph tokens to remove vertical spacing
* Tweaked help text tokens to move away from custom classes

Storybook:

![image](https://github.com/open-formulieren/design-tokens/assets/5518550/c4575898-aab2-44bc-9eab-e376ef66bc4b)

This should look identical to the existing formio components. With this patch, we should be able to phase out the custom class names.