### PR TITLE
Add tokens for validation errors display

### DIFF
--- a/src/components/errors.tokens.json
+++ b/src/components/errors.tokens.json
@@ -1,0 +1,15 @@
+{
+  "of": {
+    "utrecht-form-field-description": {
+      "$extensions": {
+        "dte.metadata": {
+          "groupDescription": "Open Forms extensions of utrecht-form-field-description (for errors)"
+        }
+      },
+      "errors": {
+        "font-weight": {"value": "bold"},
+        "line-height": {"value": 1.33}
+      }
+    }
+  }
+}


### PR DESCRIPTION
open-formulieren/open-forms-sdk#442

Validation errors can look slightly different than regular utrecht-form-field-description, which we make possible through custom design tokens for all themes (and fill out our defaults).