### PR TITLE
:alien: Correctly define the read-only background colors

### DIFF
--- a/src/common/color.tokens.json
+++ b/src/common/color.tokens.json
@@ -110,6 +110,12 @@
           "value": "#0177b2",
           "comment": "Default color for borders of focused elements."
         }
+      },
+      "read-only": {
+        "bg": {
+          "value": "#e9ecef",
+          "comment": "Default color for disabled/non-interactable input elements."
+        }
       }
     }
   }

--- a/src/community/utrecht/form-control.tokens.json
+++ b/src/community/utrecht/form-control.tokens.json
@@ -1,7 +1,10 @@
 {
   "utrecht": {
     "form-control": {
-      "background-color": {"value": "{of.color.bg}"}
+      "background-color": {"value": "{of.color.bg}"},
+      "read-only": {
+        "background-color": {"value": "{of.color.read-only.bg}"}
+      }
     }
   }
 }

--- a/src/community/utrecht/select.tokens.json
+++ b/src/community/utrecht/select.tokens.json
@@ -15,7 +15,7 @@
       "padding-inline-end": {"value": "12px"},
       "padding-inline-start": {"value": "12px"},
       "disabled": {
-        "background-color": {"value": "#e9ecef"},
+        "background-color": {"value": "{of.color.read-only.bg}"},
         "border-color": {},
         "color": {}
       },

--- a/src/community/utrecht/textbox.tokens.json
+++ b/src/community/utrecht/textbox.tokens.json
@@ -18,7 +18,10 @@
         "color": {"value": "{of.color.fg-muted}"}
       },
       "disabled": {
-        "background-color": {"value": "#e9ecef"}
+        "background-color": {"value": "{of.color.read-only.bg}"}
+      },
+      "read-only": {
+        "background-color": {"value": "{of.color.read-only.bg}"}
       }
     }
   }


### PR DESCRIPTION
I noticed in the SDK the background colors for disabled/readonly fields no longer had the grey background color.