### PR TITLE
:lipstick: Design tokens to prevent double error border

### DIFF
--- a/src/components/input-group.tokens.json
+++ b/src/components/input-group.tokens.json
@@ -3,7 +3,14 @@
     "input-group": {
       "justify-content": {"value": "flex-start"},
       "align-items": {"value": "center"},
-      "gap": {"value": "12px"}
+      "gap": {"value": "12px"},
+      "invalid": {
+        "border-inline-start": {
+          "color": {"value": "transparent"},
+          "width": {"value": "0"}
+        },
+        "padding-inline-start": {"value": "0"}
+      }
     }
   }
 }


### PR DESCRIPTION
The fieldset itself adds a border, but the container/parent field does too. The latter should be kept, because it stretches to include the validation error content.

Related to open-formulieren/open-forms-sdk#433