### PR TITLE
Set design token for current link appearance

### DIFF
--- a/src/common/typography.tokens.json
+++ b/src/common/typography.tokens.json
@@ -4,10 +4,7 @@
       "fg": {"value": "{of.color.fg}"}
     },
     "utrecht-link": {
-      "font-family": {"value": "{of.typography.sans-serif.font-family}"},
-      "muted": {
-        "color": {"value": "{of.color.fg-muted}"}
-      }
+      "font-family": {"value": "{of.typography.sans-serif.font-family}"}
     },
     "text": {
       "margin": {"value": "20px"},

--- a/src/community/utrecht/action.tokens.json
+++ b/src/community/utrecht/action.tokens.json
@@ -9,6 +9,9 @@
           "value": "not-allowed"
         }
       },
+      "inert": {
+        "cursor": {"value": "default"}
+      },
       "submit": {
         "cursor": {
           "value": "pointer"

--- a/src/community/utrecht/link.tokens.json
+++ b/src/community/utrecht/link.tokens.json
@@ -11,6 +11,9 @@
           "value": "none"
         }
       },
+      "current": {
+        "font-weight": {"value": "bold"}
+      },
       "placeholder": {
         "color": {"value": "{of.color.fg-muted}"}
       }


### PR DESCRIPTION
Related to open-formulieren/open-forms-sdk#36

Current/active links are displayed in a bolder font face.