### PR TITLE
:wheelchair: [open-formulieren/open-forms#4718] Better color contrast for danger buttons

### DIFF
--- a/src/community/utrecht/button.tokens.json
+++ b/src/community/utrecht/button.tokens.json
@@ -84,7 +84,7 @@
 
         "danger": {
           "background-color": {"value": "{of.color.danger}"},
-          "color": {"value": "#fce9e8"},
+          "color": {"value": "{of.button.danger.fg}"},
 
           "focus": {
             "border-color": {"value": "transparent"}

--- a/src/components/buttons/button.tokens.json
+++ b/src/components/buttons/button.tokens.json
@@ -18,7 +18,7 @@
       },
 
       "danger": {
-        "fg": {"value": "#fce9e8"},
+        "fg": {"value": "#ffffff"},
         "bg": {"value": "{of.color.danger}"},
         "color-border": {"value": "#aa2218"}
       }


### PR DESCRIPTION
Partially closes open-formulieren/open-forms#4718

The current danger button color scores just below the AA standard of WCAG21, at 4,28 (the threshold for AA is a score of 4,5). With this update the score will become 5,01 