### PR TITLE
:lipstick: Ensure v4 of utrecht button is full width on mobile

### DIFF
--- a/src/community/utrecht/button.tokens.json
+++ b/src/community/utrecht/button.tokens.json
@@ -9,6 +9,7 @@
       "font-size": {"value": "{of.text.big.font-size}"},
       "line-height": {"value": "1.333"},
       "min-block-size": {"value": "0"},
+      "max-inline-size": {"value": "100%"},
       "min-inline-size": {"value": "0"},
       "padding-block-start": {"value": "10.003px"},
       "padding-block-end": {"value": "10.003px"},


### PR DESCRIPTION
The default for max-inline-size is 'fit-content', which breaks our mobile styling.

Required for https://github.com/open-formulieren/open-forms-sdk/pull/803