### PR TITLE
Refactor/provide backwards compat for updated form navigation styles

### DIFF
--- a/src/community/utrecht/button.tokens.json
+++ b/src/community/utrecht/button.tokens.json
@@ -6,7 +6,12 @@
       "border-radius": {"value": "0"},
       "border-width": {"value": "2px"},
       "color": {"value": "{of.button.fg}"},
+      "column-gap": {"value": "8px"},
       "font-size": {"value": "{of.text.big.font-size}"},
+      "icon": {
+        "gap": {"value": "{utrecht.button.column-gap}"},
+        "size": {"value": "auto"}
+      },
       "line-height": {"value": "1.333"},
       "min-block-size": {"value": "0"},
       "max-inline-size": {"value": "100%"},

--- a/src/community/utrecht/icon.tokens.json
+++ b/src/community/utrecht/icon.tokens.json
@@ -1,0 +1,7 @@
+{
+  "utrecht": {
+    "icon": {
+      "size": {"value": "auto"}
+    }
+  }
+}

--- a/src/community/utrecht/link.tokens.json
+++ b/src/community/utrecht/link.tokens.json
@@ -2,6 +2,9 @@
   "utrecht": {
     "link": {
       "color": {"value": "{of.color.primary}"},
+      "icon": {
+        "size": {"value": "auto"}
+      },
       "text-decoration": {
         "value": "underline"
       },

--- a/src/components/abort-button.tokens.json
+++ b/src/components/abort-button.tokens.json
@@ -2,6 +2,7 @@
   "of": {
     "abort-button": {
       "color": {"value": "{of.color.danger}"},
+      "fa-icon": {"value": "\"\\f00d\""},
       "hover": {
         "color": {"value": "{of.color.danger}"}
       }

--- a/src/components/abort-button.tokens.json
+++ b/src/components/abort-button.tokens.json
@@ -1,0 +1,10 @@
+{
+  "of": {
+    "abort-button": {
+      "color": {"value": "{of.color.danger}"},
+      "hover": {
+        "color": {"value": "{of.color.danger}"}
+      }
+    }
+  }
+}

--- a/src/components/form-navigation.tokens.json
+++ b/src/components/form-navigation.tokens.json
@@ -8,7 +8,13 @@
         "padding-inline-end": {"value": 0},
         "padding-inline-start": {"value": 0}
       },
-      "row-gap": {"value": "8px"}
+      "row-gap": {"value": "8px"},
+      "save-button": {
+        "fa-icon": {"value": "\"\\f28b\""}
+      },
+      "next-button": {
+        "fa-icon": {"value": "\"\\f178\""}
+      }
     }
   }
 }

--- a/src/components/form-navigation.tokens.json
+++ b/src/components/form-navigation.tokens.json
@@ -1,0 +1,14 @@
+{
+  "of": {
+    "form-navigation": {
+      "icon": {
+        "size": {"value": "auto"}
+      },
+      "link-button": {
+        "padding-inline-end": {"value": 0},
+        "padding-inline-start": {"value": 0}
+      },
+      "row-gap": {"value": "8px"}
+    }
+  }
+}

--- a/src/components/previous-link.tokens.json
+++ b/src/components/previous-link.tokens.json
@@ -4,6 +4,7 @@
       "column-gap": {"value": "8px"},
       "display-start": {"value": "none"},
       "display-end": {"value": "flex"},
+      "fa-icon": {"value": "\"\\f177\""},
       "icon": {
         "display": {"value": "inline-block"},
         "size": {"value": "auto"}

--- a/src/components/previous-link.tokens.json
+++ b/src/components/previous-link.tokens.json
@@ -1,11 +1,15 @@
 {
   "of": {
     "previous-link": {
+      "column-gap": {"value": "8px"},
       "display-start": {"value": "none"},
-      "display-end": {"value": "inline-block"},
+      "display-end": {"value": "flex"},
       "icon": {
-        "display": {"value": "inline-block"}
-      }
+        "display": {"value": "inline-block"},
+        "size": {"value": "auto"}
+      },
+      "padding-block-end": {"value": "10.003px"},
+      "padding-block-start": {"value": "10.003px"}
     }
   }
 }


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#4917

The frontend code in the SDK has been restructured/refactored to lean more on NL DS components (with local overrides) so that it's easier to style the form navigation and possible for us to provide "fallback defaults" in the backend.

These available design tokens are/will be documented in the SDK in the 3.1 upgrade instructions/release notes.