### PR TITLE
Remove the utrecht-button-icon-gap token

### DIFF
--- a/src/community/utrecht/button.tokens.json
+++ b/src/community/utrecht/button.tokens.json
@@ -9,7 +9,6 @@
       "column-gap": {"value": "8px"},
       "font-size": {"value": "{of.text.big.font-size}"},
       "icon": {
-        "gap": {"value": "{utrecht.button.column-gap}"},
         "size": {"value": "auto"}
       },
       "line-height": {"value": "1.333"},


### PR DESCRIPTION
Partly closes open-formulieren/formio-renderer#301

It was removed in favour of utrecht-button-column-gap, which we already defined and the icon-gap token referred to the new token.