### PR TITLE
Fix default styling `ul` bullets

### DIFF
--- a/src/community/utrecht/ordered-list.tokens.json
+++ b/src/community/utrecht/ordered-list.tokens.json
@@ -1,0 +1,20 @@
+{
+  "utrecht": {
+    "ordered-list": {
+      "font-size": {},
+      "line-height": {},
+      "margin-block-start": {"value": "12px"},
+      "margin-block-end": {"value": "20px"},
+      "margin-inline-start": {},
+      "padding-inline-start": {},
+      "item": {
+        "margin-block-start": {},
+        "margin-block-end": {},
+        "padding-inline-start": {"value": "8px"}
+      },
+      "marker": {
+        "color": {}
+      }
+    }
+  }
+}

--- a/src/community/utrecht/unordered-list.tokens.json
+++ b/src/community/utrecht/unordered-list.tokens.json
@@ -5,11 +5,12 @@
       "line-height": {},
       "margin-block-start": {"value": "12px"},
       "margin-block-end": {"value": "20px"},
-      "padding-inline-start": {},
+      "margin-inline-start": {"value": "0"},
+      "padding-inline-start": {"value": "18px"},
       "item": {
         "margin-block-start": {"value": "4px"},
         "margin-block-end": {},
-        "padding-inline-start": {"value": "8px"}
+        "padding-inline-start": {"value": "0"}
       },
       "marker": {
         "color": {}

--- a/src/community/utrecht/unordered-list.tokens.json
+++ b/src/community/utrecht/unordered-list.tokens.json
@@ -3,6 +3,7 @@
     "unordered-list": {
       "font-size": {},
       "line-height": {},
+      "list-style-type": {"value": "disc"},
       "margin-block-start": {"value": "12px"},
       "margin-block-end": {"value": "20px"},
       "margin-inline-start": {"value": "0"},


### PR DESCRIPTION
Partly closes open-formulieren/open-forms#6410

Correct the values for the unordered list design tokens.

I couldn't find a ticket reference for the original token values, but did grep the current renderer and SDK codebases and these values should be okay, though some extra attention may be necessary for the appointments summaries in the SDK.