### PR TITLE
Remove summary progress bottom padding

### DIFF
--- a/src/components/summary-progress.tokens.json
+++ b/src/components/summary-progress.tokens.json
@@ -1,11 +1,11 @@
 {
   "of": {
     "summary-progress": {
-      "padding-block-start": {"value": "0px"},
-      "padding-block-end": {"value": "20px"},
+      "padding-block-start": {"value": 0},
+      "padding-block-end": {"value": 0},
       "mobile": {
-        "padding-block-start": {"value": "0px"},
-        "padding-block-end": {"value": "20px"}
+        "padding-block-start": {"value": 0},
+        "padding-block-end": {"value": 0}
       }
     }
   }


### PR DESCRIPTION
It's typically contained in a flex container with row-gaps that already manage the vertical spacing, so the component itself no longer needs the spacing.